### PR TITLE
Fix mouse drop action setting

### DIFF
--- a/dot_config/yabai/executable_yabairc
+++ b/dot_config/yabai/executable_yabairc
@@ -29,7 +29,7 @@ yabai -m config mouse_action1 move
 yabai -m config mouse_action2 resize
 
 # move a windows in the middle of another windows to swap them
-yabai -m mouse_drop_action swap
+yabai -m config mouse_drop_action swap
 
 # Disaple specific apps (not managed by yabai)
 yabai -m rule --add app="^System Settings$" manage=off


### PR DESCRIPTION
## Summary
- fix the yabai configuration to set `mouse_drop_action` correctly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68625808cf1c832597b868ffa61423c4