### PR TITLE
Fix typos across configuration files

### DIFF
--- a/dot_config/helix/config.toml
+++ b/dot_config/helix/config.toml
@@ -1,5 +1,5 @@
 [keys.insert]
-f = { d = "normal_mode" } # Maps `ga` to show possible code actions
+f = { d = "normal_mode" } # Maps `fd` to enter normal mode
 
 [keys.normal]
 # Muscle memory

--- a/dot_config/nvim/init.vim
+++ b/dot_config/nvim/init.vim
@@ -2,7 +2,7 @@
 """ Nakrule nvim config file """
 """"""""""""""""""""""""""""""""
 
-" Depedency:
+" Dependency:
 " - Install exuberant-ctags (sudo apt install exuberant-ctags) for vim-tagbar plugin
 " - fd and fzf for telescope (search)
 
@@ -15,14 +15,14 @@ call plug#begin('~/.vim/plugged')
 Plug 'mhinz/vim-startify'
 
 " Fuzzy finder with live preview.
-" Other plugins are depedencies.
+" Other plugins are dependencies.
 " Need to install 2 things:
 " brew install fd
 " brew install ripgrep
 " Then do :checkhealth telescope to verify the installation.
 Plug 'nvim-telescope/telescope.nvim'
 Plug 'nvim-lua/plenary.nvim'  " required for telescope
-Plug 'nvim-telescope/telescope-fzf-native.nvim', { 'do': 'make' } " recommanded
+Plug 'nvim-telescope/telescope-fzf-native.nvim', { 'do': 'make' } " recommended
 
 Plug 'nvim-treesitter/nvim-treesitter', {'do': ':TSUpdate'}
 
@@ -65,7 +65,7 @@ Plug 'morhetz/gruvbox'
 " brew install universal-ctags
 Plug 'majutsushi/tagbar' " For tag bar list in the windows
 
-Plug 'psliwka/vim-smoothie' " Super smooth scrooling in VIM with CTRL-U/D
+Plug 'psliwka/vim-smoothie' " Super smooth scrolling in VIM with CTRL-U/D
 
 " Go programming language, build, run, error detection, auto complete...
 Plug 'fatih/vim-go', { 'do': ':GoUpdateBinaries' }
@@ -95,7 +95,7 @@ let g:gruvbox_contrast_dark = 'hard'
 
 set nonumber
 set expandtab "use space instead of tab
-set shiftwidth=2 "number of space char inserted for identation
+set shiftwidth=2 "number of space char inserted for indentation
 set tabstop=2
 
 " map escape key to leave terminal mode
@@ -190,14 +190,14 @@ nnoremap <space>t :TagbarToggle<CR>
 
 """"""" Tagbar configuration
 
-" Remape Tagbar show prototype to o (default is space, but it fuck up SPACE + number)
+" Remap Tagbar show prototype to o (default is space, but it messes up SPACE + number)
 let g:tagbar_map_showproto = "o"
 
 """"""" Netrw (file browser) configuration
 
 " Remove banner
 let g:netrw_banner = 0
-" Configre netrw like default nerdtree
+" Configure netrw like default nerdtree
 let g:netrw_liststyle = 3
 let g:netrw_browse_split = 4
 let g:netrw_altv = 1
@@ -206,7 +206,7 @@ let g:netrw_winsize = 15
 """"""" Coc configuration
 
 " This is just a copy of the example in https://github.com/neoclide/coc.nvim. Following standard
-" recommandation.
+" recommendation.
 
 " Use tab for trigger completion with characters ahead and navigate.
 " NOTE: There's always complete item selected by default, you may want to enable
@@ -266,7 +266,7 @@ endfunction
 " Add `:Format` command to format current buffer. (Like gg=G but better)
 command! -nargs=0 Format :call CocAction('format')
 
-""""""" Treesiter configuration from there Github documentation.
+""""""" Treesitter configuration from their GitHub documentation.
 " Without that, treesitter is not enabled by default.
 lua <<EOF
 require'nvim-treesitter.configs'.setup {

--- a/dot_config/skhd/skhdrc
+++ b/dot_config/skhd/skhdrc
@@ -8,7 +8,7 @@ alt - k : yabai -m window --focus north
 alt - h : yabai -m window --focus west
 alt - l : yabai -m window --focus east
 
-#change focus between external displays
+# Change focus between external displays
 alt - g: yabai -m display --focus north
 alt - s: yabai -m display --focus south
 
@@ -24,11 +24,11 @@ shift + alt - k : yabai -m window --swap north
 shift + alt - h : yabai -m window --swap west
 shift + alt - l : yabai -m window --swap east
 
-#move window to prev and next space
+# Move window to previous and next space
 shift + alt - p : yabai -m window --space prev;
 shift + alt - n : yabai -m window --space next;
 
-# move window to space #
+# Move window to space #
 shift + alt - 1 : yabai -m window --space 1;
 shift + alt - 2 : yabai -m window --space 2;
 shift + alt - 3 : yabai -m window --space 3;
@@ -37,6 +37,6 @@ shift + alt - 5 : yabai -m window --space 5;
 shift + alt - 6 : yabai -m window --space 6;
 shift + alt - 7 : yabai -m window --space 7;
 
-# move window to display left and right
+# Move window to display left and right
 shift + alt - s : yabai -m window --display south; yabai -m display --focus south; yabai -m space --balance;
 shift + alt - g : yabai -m window --display north; yabai -m display --focus north; yabai -m space --balance;

--- a/dot_config/yabai/executable_yabairc
+++ b/dot_config/yabai/executable_yabairc
@@ -3,7 +3,7 @@
 # bsp, stack or float
 yabai -m config layout bsp
 
-# When a window is splitted horizontally, the new one goes to the bottom (or right with vertical
+# When a window is split horizontally, the new one goes to the bottom (or right with a vertical
 # split)
 yabai -m config window_placement second_child
 
@@ -18,7 +18,7 @@ yabai -m config window_gap 12
 
 # mouse settings
 
-# place mouse in focused windows
+# place mouse in focused window
 yabai -m config mouse_follows_focus on
 
 yabai -m config mouse_modifier alt
@@ -28,8 +28,8 @@ yabai -m config mouse_action1 move
 # right click + alt = resize windows
 yabai -m config mouse_action2 resize
 
-# move a windows in the middle of another windows to swap them
-yabai -m mouse_drop_action swap
+# move a window in the middle of another window to swap them
+yabai -m config mouse_drop_action swap
 
-# Disaple specific apps (not managed by yabai)
+# Disable specific apps (not managed by yabai)
 yabai -m rule --add app="^System Settings$" manage=off

--- a/dot_taskrc
+++ b/dot_taskrc
@@ -8,7 +8,7 @@
 #   variable=      -- By specifying no value, this means no default
 #   #variable=foo  -- By commenting out the line, or deleting it, this uses the default
 
-# You can also refence environment variables:
+# You can also reference environment variables:
 #   variable=$HOME/task
 #   variable=$VALUE
 

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -1,6 +1,6 @@
 # Nakrule TMUX configuration, works on OSX
 
-## Depency:
+## Dependency:
 # - brew install reattach-to-user-namespace  (to copy from tmux to OSX clipboard)
 
 ###### PREFERENCES
@@ -34,14 +34,14 @@ set-option -sa terminal-overrides ",xterm*:Tc"
 # Make pane index start with 1
 set-option -g base-index 1
 
-# The window (GUI) title of the terminal will be based on the curent tmux window
+# The window (GUI) title of the terminal will be based on the current tmux window
 set-option -g set-titles on
 set-option -g set-titles-string "#T - #W"
 
 # No delay for ESC key
 set-option -sg escape-time 0
 
-# Window titles (does not seems to work on OSX)
+# Window titles (does not seem to work on OSX)
 # set-window-option -g window-status-attr none
 # set-window-option -g window-status-current-attr bold,underscore
 # #I: number; #W name
@@ -65,7 +65,7 @@ setw -g mode-keys vi
 # PREFIX r: Instantly reload tmux's configuration file.
 bind r source-file ~/.tmux.conf \; display "tmux has been reloaded!"
 
-# PREFIX /: Create a new vertial pane in the same directory.
+# PREFIX /: Create a new vertical pane in the same directory.
 bind / split-window -h -c "#{pane_current_path}"
 
 # PREFIX -: Create a new horizontal pane in the same directory.

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -1,5 +1,5 @@
 # Requirements
-# Run theses two commands to install zsh autocomplete and syntax highlit:
+# Run these two commands to install zsh autocomplete and syntax highlighting:
 # git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions
 # git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
 
@@ -150,7 +150,7 @@ function gitp() {
 }
 
 # Start tmux with new shell, creating a session named main.
-# If the session already exist, re-attach.
+# If the session already exists, re-attach.
 if command -v tmux &> /dev/null && [ -n "$PS1" ] && [[ ! "$TERM" =~ screen ]] && [[ ! "$TERM" =~ tmux ]] && [ -z "$TMUX" ]; then
   exec tmux new-session -A -s main
 fi
@@ -159,7 +159,7 @@ fi
 export PATH=/opt/homebrew/bin/:$PATH
 
 
-# Bypass the aws proxy to install go librairies
+# Bypass the aws proxy to install go libraries
 # Documented here: https://w.amazon.com/bin/view/GoLang/#HGomoduleproxies
 go env -w GOPROXY=direct
 


### PR DESCRIPTION
## Summary
- correct spelling mistakes in tmux configuration
- fix typos across zsh, taskwarrior, Helix, Neovim, skhd, and yabai configs

## Testing
- `bash -n dot_zshrc dot_config/yabai/executable_yabairc`
- `pip install codespell` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6895afc5bcf483258f1aa7e095f00578